### PR TITLE
AMv2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ gen: proto converter
 .PHONY: converter
 converter: $(CONVERTERS)
 
+src/smartnews/converter/creative.cr:
+	# ### This file is maintained by hands.
+
 src/smartnews/converter/%.cr:proto/smartnews/%.proto $(GENERATOR)
 	@if ! which "$(GENERATOR)" > /dev/null ; then echo "GENERATOR not set"; exit 1; fi
 	$(GENERATOR) pb schema2converter $< "Smartnews::" > $@
@@ -79,7 +82,7 @@ proto: $(subst json,proto,$(JSON_FILES))
 	@mkdir -p src/proto
 	protoc -I proto --crystal_out src/proto proto/*.proto
 	@mkdir -p src/smartnews/proto
-	PROTOBUF_NS=Smartnews::Proto protoc -I proto -I proto/smartnews --crystal_out src/smartnews/proto proto/smartnews/*.proto
+	for pb in proto/smartnews/*.proto; do PROTOBUF_NS=Smartnews::Proto protoc -I proto -I proto/smartnews --crystal_out src/smartnews/proto $$pb; done
 
 ######################################################################
 ### versioning

--- a/proto/smartnews/amv2.proto
+++ b/proto/smartnews/amv2.proto
@@ -1,0 +1,14 @@
+syntax = "proto2";
+
+message Amv2 {
+  optional string campaignId            = 1; // "1000004"
+  optional string campaignName          = 2; // "test"
+  optional string adGroupId             = 3; // "1000003"
+  optional string adGroupName           = 4; // "test"
+  optional int64  campaignSpendingLimit = 5; // 100
+  optional int64  campaignDailyBudget   = 6; // 100
+}
+
+message Amv2Array {
+  repeated Amv2 array = 1;
+}

--- a/proto/smartnews/campaign.proto
+++ b/proto/smartnews/campaign.proto
@@ -1,5 +1,7 @@
 syntax = "proto2";
 
+import "amv2.proto";
+
 message Campaign {
   optional string actionType     = 1  ; // "WEBSITE_CONVERSION"
   optional string name           = 2  ; // "SmartNews Installs 7/12"
@@ -19,6 +21,7 @@ message Campaign {
   optional string status         = 16 ; // "NORMAL"
   optional string approvalStatus = 17 ; // "APPROVED"
   optional string updatedAt      = 18 ; // "2020-01-31T02:02:03Z"
+  optional Amv2   amv2           = 19 ; 
 }
 
 message CampaignArray {

--- a/proto/smartnews/report.proto
+++ b/proto/smartnews/report.proto
@@ -74,6 +74,14 @@ message Report {
   optional int64  addToCart             = 59;
   optional int64  completeRegistration  = 60;
   optional int64  subscribe             = 61;
+
+  // campaign.amV2
+  optional string amv2_campaignId            = 62; // "1000004"
+  optional string amv2_campaignName          = 63; // "test"
+  optional string amv2_adGroupId             = 64; // "1000003"
+  optional string amv2_adGroupName           = 65; // "test"
+  optional int64  amv2_campaignSpendingLimit = 66; // 100
+  optional int64  amv2_campaignDailyBudget   = 67; // 100
 }
 
 message ReportArray {

--- a/shard.yml
+++ b/shard.yml
@@ -33,5 +33,6 @@ development_dependencies:
     github: maiha/shell.cr
   toml-config:
     github: maiha/toml-config.cr
+    version: 0.6.0
 
 license: MIT

--- a/src/cli/cmds/batch/tsv.cr
+++ b/src/cli/cmds/batch/tsv.cr
@@ -42,16 +42,34 @@ class Cmds::BatchCmd
       max = creatives_hash[cid].imageset.try(&.sort_by{|i| i.width || 0_i64}.last?) || next
       creatives_max_imageinfo_hash[cid] = max
     end
-    
+
+    amv2_hash = Hash(String, Smartnews::Proto::Amv2).new # key: v1.campaignId (= v2.adGroupId)
+    campaigns.each_with_index do |c, i|
+      amv2 = c.amv2 || next
+      ad_group_id = amv2.ad_group_id || next
+      amv2_hash[ad_group_id] = amv2
+    end
+
 
     disk.measure {
       buf = CSV.build(quoting: tsv_quote, separator: tsv_sep) do |csv|
         csv.row(keys)           # header
         insights.each do |insight|
           vals = Array(String).new
+          amv2 = amv2_hash[insight.campaign_id.to_s]? || Smartnews::Proto::Amv2.new
+
           keys.each do |key|
             if key == "date"
               vals << partition_key
+            elsif key =~ /^amv2_(.*)$/
+              _key = $1
+              _val = amv2[_key]?
+              if f = Smartnews::Proto::Report::Fields[key]?
+                vals << tsv_serialize(_val, f)
+              else
+                logger.warn "wrong amv2 key: [#{key}] is not a member of Report::Fields. insight=#{insight.inspect}"
+                vals << tsv_serialize(nil)
+              end
             elsif f = Smartnews::Proto::Insight::Fields[key]?
               vals << tsv_serialize(insight[key]?, f)
             elsif f = Smartnews::Proto::Campaign::Fields[key]?

--- a/src/smartnews/converter/amv2.cr
+++ b/src/smartnews/converter/amv2.cr
@@ -1,0 +1,71 @@
+class Smartnews::Converter::Amv2
+  ######################################################################
+  ### JSON
+
+  JSON.mapping({
+    campaignId:            String? , # "1000004"
+    campaignName:          String? , # "test"
+    adGroupId:             String? , # "1000003"
+    adGroupName:           String? , # "test"
+    campaignSpendingLimit: Int64?  , # 100
+    campaignDailyBudget:   Int64?  , # 100
+  })
+
+  ######################################################################
+  ### Protobuf
+
+  def to_pb
+    Smartnews::Proto::Amv2.new(
+      campaign_id: campaignId,
+      campaign_name: campaignName,
+      ad_group_id: adGroupId,
+      ad_group_name: adGroupName,
+      campaign_spending_limit: campaignSpendingLimit,
+      campaign_daily_budget: campaignDailyBudget,
+    )
+  end
+
+  def self.protobuf_schema : ProtobufSchema::Schema
+    ProtobufSchema.parse(protobuf_schema_string)
+  end
+
+  def self.protobuf_schema_string : String
+    <<-EOF
+      syntax = "proto2";
+      
+      message Amv2 {
+        optional string campaignId            = 1; // "1000004"
+        optional string campaignName          = 2; // "test"
+        optional string adGroupId             = 3; // "1000003"
+        optional string adGroupName           = 4; // "test"
+        optional int64  campaignSpendingLimit = 5; // 100
+        optional int64  campaignDailyBudget   = 6; // 100
+      }
+      
+      message Amv2Array {
+        repeated Amv2 array = 1;
+      }
+      EOF
+  end
+
+  ######################################################################
+  ### ClickHouse
+
+  def self.clickhouse_create : Clickhouse::Schema::Create
+    Clickhouse::Schema::Create.parse(clickhouse_schema_sql)
+  end
+
+  def self.clickhouse_schema_sql
+    <<-EOF
+      CREATE TABLE amv2 (
+        campaign_id Nullable(String),
+        campaign_name Nullable(String),
+        ad_group_id Nullable(String),
+        ad_group_name Nullable(String),
+        campaign_spending_limit Nullable(Int64),
+        campaign_daily_budget Nullable(Int64)
+      )
+      ENGINE = Log
+      EOF
+  end
+end

--- a/src/smartnews/converter/campaign.cr
+++ b/src/smartnews/converter/campaign.cr
@@ -21,6 +21,7 @@ class Smartnews::Converter::Campaign
     status:         String? , # "NORMAL"
     approvalStatus: String? , # "APPROVED"
     updatedAt:      String? , # "2020-01-31T02:02:03Z"
+    amv2:           Smartnews::Proto::Amv2? , #
   })
 
   ######################################################################
@@ -46,6 +47,7 @@ class Smartnews::Converter::Campaign
       status: status,
       approval_status: approvalStatus,
       updated_at: updatedAt,
+      amv2: amv2,
     )
   end
 
@@ -56,6 +58,8 @@ class Smartnews::Converter::Campaign
   def self.protobuf_schema_string : String
     <<-EOF
       syntax = "proto2";
+      
+      import "amv2.proto";
       
       message Campaign {
         optional string actionType     = 1  ; // "WEBSITE_CONVERSION"
@@ -76,6 +80,7 @@ class Smartnews::Converter::Campaign
         optional string status         = 16 ; // "NORMAL"
         optional string approvalStatus = 17 ; // "APPROVED"
         optional string updatedAt      = 18 ; // "2020-01-31T02:02:03Z"
+        optional Amv2   amv2           = 19 ; 
       }
       
       message CampaignArray {
@@ -111,7 +116,8 @@ class Smartnews::Converter::Campaign
         creative_type Nullable(String),
         status Nullable(String),
         approval_status Nullable(String),
-        updated_at Nullable(String)
+        updated_at Nullable(String),
+        amv2 Nullable(String)
       )
       ENGINE = Log
       EOF

--- a/src/smartnews/converter/creative.cr
+++ b/src/smartnews/converter/creative.cr
@@ -1,3 +1,5 @@
+### This file is maintained by hands.
+
 class Smartnews::Converter::Creative
   ######################################################################
   ### JSON

--- a/src/smartnews/converter/report.cr
+++ b/src/smartnews/converter/report.cr
@@ -3,67 +3,73 @@ class Smartnews::Converter::Report
   ### JSON
 
   JSON.mapping({
-    date:                  String   , # "2019-12-31"
-    accountId:             String?  , # "1000000"
-    campaignId:            String?  , # "1000003"
-    creativeId:            String?  , # "1000013"
-    accountName:           String?  , # "SmartNews, Inc"
-    campaignName:          String?  , # "SmartNews Installs 7/12"
-    creativeName:          String?  , # "label for creative management"
-    impressions:           Int64?   , # 13204
-    viewableImpressions:   Int64?   , # 10444
-    clicks:                Int64?   , # 48
-    conversions:           Int64?   , # 3
-    spend:                 Float64? , # 1052.5128
-    cpm:                   Float64? , # 100.77678752999999
-    cpc:                   Float64? , # 21.92734935
-    ctr:                   Float64? , # 0.36353
-    vctr:                  Float64? , # 0.45959
-    cvr:                   Float64? , # 6.25
-    cpa:                   Float64? , # 350.83758967
-    actionType:            String?  , # "WEBSITE_CONVERSION"
-    enable:                Bool?    , # true
-    startTime:             String?  , # "2019-09-17T15:00:00Z"
-    endTime:               String?  , # "2020-02-29T14:59:00Z"
-    totalBudget:           Int64?   , # 1026473
-    dailyBudget:           Int64?   , # 4116
-    bidAmount:             Int64?   , # 50
-    billingEvent:          String?  , # "CLICKS"
-    isAutoBid:             Bool?    , # true
-    sponsoredName:         String?  , # "SmartAds"
-    targetCpa:             Int64?   , # 0
-    status:                String?  , # "NORMAL"
-    approvalStatus:        String?  , # "APPROVED"
-    updatedAt:             String?  , # "2020-01-31T02:02:03Z"
-    adcreativeId:          String?  , # "10000005"
-    creativeType:          String?  , # "IMAGE"
-    isDynamicCreative:     Bool?    , # false
-    immutable:             Bool?    , # true
-    title:                 String?  , # "Trending News & Stories"
-    text:                  String?  , # "Your news in one minute."
-    linkUrl:               String?  , # "http://creative.smartnews-ads.com"
-    trackingUrl:           String?  , # "http://foo.trackingsystem.com/?a=b&c=d&e=f"
-    videoAvgViewRate:      Float64? , # 41.20017
-    videoAvgViewTime:      Float64? , # 4085.73368
-    videoCompleteViewRate: Float64? , # 43.09866
-    videoCompleteViews:    Int64?   , # 1861
-    videoLength:           Int64?   , # 9915
-    videoP100Views:        Int64?   , # 1861
-    videoP25Views:         Int64?   , # 3426
-    videoP50Views:         Int64?   , # 2834
-    videoP75Views:         Int64?   , # 2266
-    videoP95Views:         Int64?   , # 1876
-    videoViewableViews:    Int64?   , # 3603
-    videoViews:            Int64?   , # 4318
-    imageId:               String?  , #
-    imageUrl:              String?  , #
-    width:                 Int64?   , #
-    height:                Int64?   , #
-    viewContent:           Int64?   , #
-    purchase:              Int64?   , #
-    addToCart:             Int64?   , #
-    completeRegistration:  Int64?   , #
-    subscribe:             Int64?   , #
+    date:                       String   , # "2019-12-31"
+    accountId:                  String?  , # "1000000"
+    campaignId:                 String?  , # "1000003"
+    creativeId:                 String?  , # "1000013"
+    accountName:                String?  , # "SmartNews, Inc"
+    campaignName:               String?  , # "SmartNews Installs 7/12"
+    creativeName:               String?  , # "label for creative management"
+    impressions:                Int64?   , # 13204
+    viewableImpressions:        Int64?   , # 10444
+    clicks:                     Int64?   , # 48
+    conversions:                Int64?   , # 3
+    spend:                      Float64? , # 1052.5128
+    cpm:                        Float64? , # 100.77678752999999
+    cpc:                        Float64? , # 21.92734935
+    ctr:                        Float64? , # 0.36353
+    vctr:                       Float64? , # 0.45959
+    cvr:                        Float64? , # 6.25
+    cpa:                        Float64? , # 350.83758967
+    actionType:                 String?  , # "WEBSITE_CONVERSION"
+    enable:                     Bool?    , # true
+    startTime:                  String?  , # "2019-09-17T15:00:00Z"
+    endTime:                    String?  , # "2020-02-29T14:59:00Z"
+    totalBudget:                Int64?   , # 1026473
+    dailyBudget:                Int64?   , # 4116
+    bidAmount:                  Int64?   , # 50
+    billingEvent:               String?  , # "CLICKS"
+    isAutoBid:                  Bool?    , # true
+    sponsoredName:              String?  , # "SmartAds"
+    targetCpa:                  Int64?   , # 0
+    status:                     String?  , # "NORMAL"
+    approvalStatus:             String?  , # "APPROVED"
+    updatedAt:                  String?  , # "2020-01-31T02:02:03Z"
+    adcreativeId:               String?  , # "10000005"
+    creativeType:               String?  , # "IMAGE"
+    isDynamicCreative:          Bool?    , # false
+    immutable:                  Bool?    , # true
+    title:                      String?  , # "Trending News & Stories"
+    text:                       String?  , # "Your news in one minute."
+    linkUrl:                    String?  , # "http://creative.smartnews-ads.com"
+    trackingUrl:                String?  , # "http://foo.trackingsystem.com/?a=b&c=d&e=f"
+    videoAvgViewRate:           Float64? , # 41.20017
+    videoAvgViewTime:           Float64? , # 4085.73368
+    videoCompleteViewRate:      Float64? , # 43.09866
+    videoCompleteViews:         Int64?   , # 1861
+    videoLength:                Int64?   , # 9915
+    videoP100Views:             Int64?   , # 1861
+    videoP25Views:              Int64?   , # 3426
+    videoP50Views:              Int64?   , # 2834
+    videoP75Views:              Int64?   , # 2266
+    videoP95Views:              Int64?   , # 1876
+    videoViewableViews:         Int64?   , # 3603
+    videoViews:                 Int64?   , # 4318
+    imageId:                    String?  , #
+    imageUrl:                   String?  , #
+    width:                      Int64?   , #
+    height:                     Int64?   , #
+    viewContent:                Int64?   , #
+    purchase:                   Int64?   , #
+    addToCart:                  Int64?   , #
+    completeRegistration:       Int64?   , #
+    subscribe:                  Int64?   , #
+    amv2_campaignId:            String?  , # "1000004"
+    amv2_campaignName:          String?  , # "test"
+    amv2_adGroupId:             String?  , # "1000003"
+    amv2_adGroupName:           String?  , # "test"
+    amv2_campaignSpendingLimit: Int64?   , # 100
+    amv2_campaignDailyBudget:   Int64?   , # 100
   })
 
   ######################################################################
@@ -131,7 +137,13 @@ class Smartnews::Converter::Report
       purchase: purchase,
       add_to_cart: addToCart,
       complete_registration: completeRegistration,
-      subscribe: subscribe
+      subscribe: subscribe,
+      amv2_campaign_id: amv2_campaignId,
+      amv2_campaign_name: amv2_campaignName,
+      amv2_ad_group_id: amv2_adGroupId,
+      amv2_ad_group_name: amv2_adGroupName,
+      amv2_campaign_spending_limit: amv2_campaignSpendingLimit,
+      amv2_campaign_daily_budget: amv2_campaignDailyBudget,
     )
   end
 
@@ -217,6 +229,14 @@ class Smartnews::Converter::Report
         optional int64  addToCart             = 59;
         optional int64  completeRegistration  = 60;
         optional int64  subscribe             = 61;
+      
+        // campaign.amV2
+        optional string amv2_campaignId            = 62; // "1000004"
+        optional string amv2_campaignName          = 63; // "test"
+        optional string amv2_adGroupId             = 64; // "1000003"
+        optional string amv2_adGroupName           = 65; // "test"
+        optional int64  amv2_campaignSpendingLimit = 66; // 100
+        optional int64  amv2_campaignDailyBudget   = 67; // 100
       }
       
       message ReportArray {
@@ -295,7 +315,13 @@ class Smartnews::Converter::Report
         purchase Nullable(Int64),
         add_to_cart Nullable(Int64),
         complete_registration Nullable(Int64),
-        subscribe Nullable(Int64)
+        subscribe Nullable(Int64),
+        amv2_campaign_id Nullable(String),
+        amv2_campaign_name Nullable(String),
+        amv2_ad_group_id Nullable(String),
+        amv2_ad_group_name Nullable(String),
+        amv2_campaign_spending_limit Nullable(Int64),
+        amv2_campaign_daily_budget Nullable(Int64)
       )
       ENGINE = Log
       EOF

--- a/src/smartnews/proto/amv2.pb.cr
+++ b/src/smartnews/proto/amv2.pb.cr
@@ -1,0 +1,28 @@
+## Generated from amv2.proto
+require "protobuf"
+
+module Smartnews
+  module Proto
+    
+    struct Amv2
+      include ::Protobuf::Message
+      
+      contract_of "proto2" do
+        optional :campaign_id, :string, 1
+        optional :campaign_name, :string, 2
+        optional :ad_group_id, :string, 3
+        optional :ad_group_name, :string, 4
+        optional :campaign_spending_limit, :int64, 5
+        optional :campaign_daily_budget, :int64, 6
+      end
+    end
+    
+    struct Amv2Array
+      include ::Protobuf::Message
+      
+      contract_of "proto2" do
+        repeated :array, Amv2, 1
+      end
+    end
+    end
+  end

--- a/src/smartnews/proto/campaign.pb.cr
+++ b/src/smartnews/proto/campaign.pb.cr
@@ -1,6 +1,8 @@
 ## Generated from smartnews/campaign.proto
 require "protobuf"
 
+require "./amv2.pb.cr"
+
 module Smartnews
   module Proto
     
@@ -26,6 +28,7 @@ module Smartnews
         optional :status, :string, 16
         optional :approval_status, :string, 17
         optional :updated_at, :string, 18
+        optional :amv2, Amv2, 19
       end
     end
     

--- a/src/smartnews/proto/report.pb.cr
+++ b/src/smartnews/proto/report.pb.cr
@@ -69,6 +69,12 @@ module Smartnews
         optional :add_to_cart, :int64, 59
         optional :complete_registration, :int64, 60
         optional :subscribe, :int64, 61
+        optional :amv2_campaign_id, :string, 62
+        optional :amv2_campaign_name, :string, 63
+        optional :amv2_ad_group_id, :string, 64
+        optional :amv2_ad_group_name, :string, 65
+        optional :amv2_campaign_spending_limit, :int64, 66
+        optional :amv2_campaign_daily_budget, :int64, 67
       end
     end
     


### PR DESCRIPTION
ベースはほぼ pr/7 です。以下を変更しました。
* proto: `amv2` の取得先を `insight` → `campaign` に変更 (実際にデータ取得できている情報を優先)
* tsv: amv2の辞書を作成 (insightから直接参照できないためcampaignId経由でアクセス)
* make: protoの入れ子に対応。 `converter` 作成時にcampaignを除外 (amv2部分が手修正のため)